### PR TITLE
Add multiple notes to a contact

### DIFF
--- a/express-api/server.js
+++ b/express-api/server.js
@@ -159,6 +159,30 @@ server.patch("/contacts/:id/favorite", async (req, res) => {
     }
 });
 
+// Create a new note on a contact (POST /contacts/:id/notes)
+server.post("/contacts/:id/notes", async (req, res) => {
+    const id = req.params.id; // get id from request URL
+
+    try {
+        const objectId = new ObjectId(id); // create ObjectId from id
+        const note = req.body; // get note object from request body
+        const result = await db
+            .collection("contacts")
+            .updateOne(
+                { _id: objectId },
+                { $push: { notes: note } }
+            ); // Add note to contact in database
+
+        if (result.acknowledged) {
+            res.json({ message: `Added note to contact with id ${id}` }); // return message
+        } else {
+            res.status(500).json({ message: "Failed to add note to contact" }); // return error message
+        }
+    } catch (error) {
+        res.status(400).json({ message: "Invalid ObjectId" }); // return 400 and error message for invalid ObjectId
+    }
+});
+
 // ========== Start server ========== //
 
 // Start server on whatever port is set in the environment variable PORT

--- a/express-api/server.js
+++ b/express-api/server.js
@@ -183,6 +183,31 @@ server.post("/contacts/:id/notes", async (req, res) => {
     }
 });
 
+// Retrieve a single note from a contact (GET /contacts/:contactId/notes/:noteIndex)
+server.get("/contacts/:contactId/notes/:noteIndex", async (req, res) => {
+    const contactId = req.params.contactId; // get contactId from request URL
+    const noteIndex = parseInt(req.params.noteIndex); // get noteIndex from request URL and parse it as an integer
+
+    try {
+        const objectId = new ObjectId(contactId); // create ObjectId from contactId
+        const contact = await db
+            .collection("contacts")
+            .findOne({ _id: objectId }); // Get the contact from the database
+
+        if (contact) {
+            const note = contact.notes[noteIndex];
+            if (!note) {
+                res.status(404).json({ message: "Note not found" });
+            }
+            res.json(note);
+        } else {
+            res.status(404).json({ message: "Contact not found" });
+        }
+    } catch (error) {
+        res.status(400).json({ message: "Invalid ObjectId" }); // return 400 and error message for invalid ObjectId
+    }
+});
+
 // ========== Start server ========== //
 
 // Start server on whatever port is set in the environment variable PORT

--- a/remix-app/app/routes/contacts.$contactId.jsx
+++ b/remix-app/app/routes/contacts.$contactId.jsx
@@ -18,58 +18,72 @@ export default function Contact() {
   const { contact } = useLoaderData();
 
   return (
-    <div id="contact">
-      <div>
-        <img
-          alt={`${contact.first} ${contact.last} avatar`}
-          key={contact.avatar}
-          src={contact.avatar}
-        />
-      </div>
-
-      <div>
-        <h1>
-          {contact.first || contact.last ? (
-            <>
-              {contact.first} {contact.last}
-            </>
-          ) : (
-            <i>No Name</i>
-          )}{" "}
-          <Favorite contact={contact} />
-        </h1>
-
-        {contact.twitter ? (
-          <p>
-            <a href={`https://twitter.com/${contact.twitter}`}>
-              {contact.twitter}
-            </a>
-          </p>
-        ) : null}
-
-        {contact.notes ? <p>{contact.notes}</p> : null}
+    <div>
+      <div id="contact">
+        <div>
+          <img
+            alt={`${contact.first} ${contact.last} avatar`}
+            key={contact.avatar}
+            src={contact.avatar}
+          />
+        </div>
 
         <div>
-          <Form action="edit">
-            <button type="submit">Edit</button>
-          </Form>
+          <h1>
+            {contact.first || contact.last ? (
+              <>
+                {contact.first} {contact.last}
+              </>
+            ) : (
+              <i>No Name</i>
+            )}{" "}
+            <Favorite contact={contact} />
+          </h1>
 
-          <Form
-            action="destroy"
-            method="post"
-            onSubmit={(event) => {
-              const response = confirm(
-                "Please confirm you want to delete this record.",
-              );
-              if (!response) {
-                event.preventDefault();
-              }
-            }}
-          >
-            <button type="submit">Delete</button>
-          </Form>
+          {contact.twitter ? (
+            <p>
+              <a href={`https://twitter.com/${contact.twitter}`}>
+                {contact.twitter}
+              </a>
+            </p>
+          ) : null}
+          <div>
+            <Form action="edit">
+              <button type="submit">Edit</button>
+            </Form>
+
+            <Form
+              action="destroy"
+              method="post"
+              onSubmit={(event) => {
+                const response = confirm(
+                  "Please confirm you want to delete this record.",
+                );
+                if (!response) {
+                  event.preventDefault();
+                }
+              }}
+            >
+              <button type="submit">Delete</button>
+            </Form>
+          </div>
         </div>
       </div>
+      {contact.notes?.length > 0 && (
+        <div>
+          <h2 className="mb-3 mt-4 text-2xl font-bold">Notes</h2>
+          <ul>
+            {contact.notes.map((note, index) => (
+              <li
+                key={index}
+                className="border-t border-gray-200 last:border-b"
+              >
+                <p className="py-3">{note}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/remix-app/app/routes/contacts.$contactId.jsx
+++ b/remix-app/app/routes/contacts.$contactId.jsx
@@ -81,9 +81,9 @@ export default function Contact() {
       </Form>
       {contact.notes?.length > 0 && (
         <ul>
-          {contact.notes.map((note, index) => (
+          {[...contact.notes].reverse().map((item, index) => (
             <li key={index} className="border-b border-gray-200">
-              <p className="py-3">{note}</p>
+              <p className="py-3">{item.note}</p>
             </li>
           ))}
         </ul>
@@ -92,16 +92,33 @@ export default function Contact() {
   );
 }
 
-export async function action({ params }) {
+export async function action({ request, params }) {
   invariant(params.contactId, "Missing contactId param");
-  const response = await fetch(
-    process.env.API_URL + "/contacts/" + params.contactId + "/favorite",
-    {
-      method: "PATCH",
-    },
-  );
-  if (!response.ok) {
-    throw new Error("Failed to update favorite");
+  const formData = await request.formData();
+  if (formData.has("favorite")) {
+    const response = await fetch(
+      process.env.API_URL + "/contacts/" + params.contactId + "/favorite",
+      {
+        method: "PATCH",
+      },
+    );
+    if (!response.ok) {
+      throw new Error("Failed to update favorite");
+    }
+  } else if (formData.has("note")) {
+    const response = await fetch(
+      process.env.API_URL + "/contacts/" + params.contactId + "/notes",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(Object.fromEntries(formData)),
+      },
+    );
+    if (!response.ok) {
+      throw new Error("Failed to create note");
+    }
   }
   return null;
 }

--- a/remix-app/app/routes/contacts.$contactId.jsx
+++ b/remix-app/app/routes/contacts.$contactId.jsx
@@ -70,7 +70,12 @@ export default function Contact() {
         </div>
       </div>
       <h2 className="mb-3 mt-4 text-2xl font-bold">Notes</h2>
-      <Form method="post" className="flex flex-row items-center gap-3">
+      {/* Add a key to the form to reset the state and clear the input when the contact changes */}
+      <Form
+        method="post"
+        className="flex flex-row items-center gap-3"
+        key={contact._id}
+      >
         <input
           type="text"
           className="mb-0 flex-grow rounded border border-gray-300 p-2"

--- a/remix-app/app/routes/contacts.$contactId.jsx
+++ b/remix-app/app/routes/contacts.$contactId.jsx
@@ -1,4 +1,11 @@
-import { Form, json, useFetcher, useLoaderData } from "@remix-run/react";
+import {
+  Form,
+  NavLink,
+  Outlet,
+  json,
+  useFetcher,
+  useLoaderData,
+} from "@remix-run/react";
 import invariant from "tiny-invariant";
 
 export async function loader({ params }) {
@@ -69,30 +76,50 @@ export default function Contact() {
           </div>
         </div>
       </div>
-      <h2 className="mb-3 mt-4 text-2xl font-bold">Notes</h2>
-      {/* Add a key to the form to reset the state and clear the input when the contact changes */}
-      <Form
-        method="post"
-        className="flex flex-row items-center gap-3"
-        key={contact._id}
-      >
-        <input
-          type="text"
-          className="mb-0 flex-grow rounded border border-gray-300 p-2"
-          placeholder={`New note about ${contact.first}`}
-          name="note"
-        />
-        <button type="submit">Save</button>
-      </Form>
-      {contact.notes?.length > 0 && (
-        <ul>
-          {[...contact.notes].reverse().map((item, index) => (
-            <li key={index} className="border-b border-gray-200">
-              <p className="py-3">{item.note}</p>
-            </li>
-          ))}
-        </ul>
-      )}
+      <div id="notes">
+        <div id="note-form">
+          <h2 className="mb-3 mt-4 text-2xl font-bold">Notes</h2>
+          {/* Add a key to the form to reset the state and clear the input when the contact changes */}
+          <Form
+            method="post"
+            className="flex flex-row items-center gap-3"
+            key={contact._id}
+          >
+            <input
+              type="text"
+              className="mb-0 flex-grow rounded border border-gray-300 p-2"
+              placeholder={`New note about ${contact.first}`}
+              name="note"
+            />
+            <button type="submit">Save</button>
+          </Form>
+          {contact.notes?.length > 0 && (
+            <div className="mt-8 flex flex-row gap-6">
+              <ul className="flex-grow">
+                {[...contact.notes].reverse().map((item, index) => (
+                  <li
+                    key={index}
+                    className="border-b border-gray-200 first:border-t"
+                  >
+                    <NavLink
+                      to={`notes/${index}`}
+                      className={({ isActive }) => {
+                        return (
+                          "block px-2 py-3 transition-colors hover:bg-gray-50" +
+                          (isActive ? " bg-gray-50 font-bold" : "")
+                        );
+                      }}
+                    >
+                      {item.note}
+                    </NavLink>
+                  </li>
+                ))}
+              </ul>
+              <Outlet />
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/remix-app/app/routes/contacts.$contactId.jsx
+++ b/remix-app/app/routes/contacts.$contactId.jsx
@@ -96,7 +96,7 @@ export default function Contact() {
           {contact.notes?.length > 0 && (
             <div className="mt-8 flex flex-row gap-6">
               <ul className="flex-grow">
-                {[...contact.notes].reverse().map((item, index) => (
+                {contact.notes.map((item, index) => (
                   <li
                     key={index}
                     className="border-b border-gray-200 first:border-t"

--- a/remix-app/app/routes/contacts.$contactId.jsx
+++ b/remix-app/app/routes/contacts.$contactId.jsx
@@ -69,20 +69,24 @@ export default function Contact() {
           </div>
         </div>
       </div>
+      <h2 className="mb-3 mt-4 text-2xl font-bold">Notes</h2>
+      <Form method="post" className="flex flex-row items-center gap-3">
+        <input
+          type="text"
+          className="mb-0 flex-grow rounded border border-gray-300 p-2"
+          placeholder={`New note about ${contact.first}`}
+          name="note"
+        />
+        <button type="submit">Save</button>
+      </Form>
       {contact.notes?.length > 0 && (
-        <div>
-          <h2 className="mb-3 mt-4 text-2xl font-bold">Notes</h2>
-          <ul>
-            {contact.notes.map((note, index) => (
-              <li
-                key={index}
-                className="border-t border-gray-200 last:border-b"
-              >
-                <p className="py-3">{note}</p>
-              </li>
-            ))}
-          </ul>
-        </div>
+        <ul>
+          {contact.notes.map((note, index) => (
+            <li key={index} className="border-b border-gray-200">
+              <p className="py-3">{note}</p>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/remix-app/app/routes/contacts.$contactId.notes.$noteIndex.jsx
+++ b/remix-app/app/routes/contacts.$contactId.notes.$noteIndex.jsx
@@ -1,0 +1,40 @@
+import { json } from "@remix-run/node";
+import { useLoaderData, useNavigate } from "@remix-run/react";
+
+export async function loader({ params }) {
+  const noteResponse = await fetch(
+    process.env.API_URL +
+      "/contacts/" +
+      params.contactId +
+      "/notes/" +
+      params.noteIndex,
+  );
+
+  if (!noteResponse.ok) {
+    const error = await noteResponse.json();
+    throw new Response(error.message, { status: noteResponse.status });
+  }
+
+  const note = await noteResponse.json();
+
+  return json({ note });
+}
+
+export default function Note() {
+  const { note } = useLoaderData();
+  const navigate = useNavigate();
+
+  return (
+    <div id="note-details" className="basis-1/4">
+      <p className="rounded border border-gray-200 p-3">{note.note}</p>
+      <button
+        className="mt-4"
+        onClick={() => {
+          navigate("..");
+        }}
+      >
+        Close
+      </button>
+    </div>
+  );
+}

--- a/remix-app/app/routes/contacts.$contactId_.edit.jsx
+++ b/remix-app/app/routes/contacts.$contactId_.edit.jsx
@@ -57,10 +57,6 @@ export default function EditContact() {
           type="text"
         />
       </label>
-      <label>
-        <span>Notes</span>
-        <textarea defaultValue={contact.notes} name="notes" rows={6} />
-      </label>
       <p>
         <button type="submit">Save</button>
         <button type="button" onClick={() => navigate(-1)}>


### PR DESCRIPTION
Closes #4 

Moves the "notes" input to the contact details page (instead of the edit page) and shows a list of notes, each of which can be opened in a detail view (to which we can later add edit and delete functionality in #6).

Currently fetches notes by their array index in the database, which is a bad idea — we'll add individual `_id`s in #7.


https://github.com/bewildergeist/dob-remix-contacts/assets/121186/3f329f5d-89d8-4828-b4c9-ab927c6427f3