### PR TITLE
Add error boundaries on contacts and notes

### DIFF
--- a/express-api/server.js
+++ b/express-api/server.js
@@ -68,7 +68,7 @@ server.get("/contacts/:id", async (req, res) => {
         if (contact) {
             res.json(contact); // return first contact from results as JSON
         } else {
-            res.status(404).json({ message: "Contact not found!" }); // otherwise return 404 and error message
+            res.status(404).json({ message: "Contact not found" }); // otherwise return 404 and error message
         }
     } catch (error) {
         res.status(400).json({ message: "Invalid ObjectId" }); // return 400 and error message for invalid ObjectId
@@ -152,7 +152,7 @@ server.patch("/contacts/:id/favorite", async (req, res) => {
                 message: `Toggled favorite property of contact with id ${id}`,
             }); // return message
         } else {
-            res.status(404).json({ message: "Contact not found!" }); // return 404 if contact was not found
+            res.status(404).json({ message: "Contact not found" }); // return 404 if contact was not found
         }
     } catch (error) {
         res.status(400).json({ message: "Invalid ObjectId" }); // return 400 and error message for invalid ObjectId

--- a/remix-app/app/components/ErrorMessage.jsx
+++ b/remix-app/app/components/ErrorMessage.jsx
@@ -1,0 +1,15 @@
+export default function ErrorMessage({ title, message, className }) {
+  return (
+    <div
+      className={[
+        "rounded border border-red-500 bg-red-100 p-4 text-red-900",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <h2 className="mb-3 text-xl font-bold">{title}</h2>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/remix-app/app/routes/contacts.$contactId.jsx
+++ b/remix-app/app/routes/contacts.$contactId.jsx
@@ -2,11 +2,14 @@ import {
   Form,
   NavLink,
   Outlet,
+  isRouteErrorResponse,
   json,
   useFetcher,
   useLoaderData,
+  useRouteError,
 } from "@remix-run/react";
 import invariant from "tiny-invariant";
+import ErrorMessage from "~/components/ErrorMessage";
 
 export async function loader({ params }) {
   invariant(params.contactId, "Missing contactId param");
@@ -172,4 +175,21 @@ function Favorite({ contact }) {
       </button>
     </fetcher.Form>
   );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    return (
+      <ErrorMessage
+        title={error.status + " " + error.statusText}
+        message={error.data}
+      />
+    );
+  } else if (error instanceof Error) {
+    return <ErrorMessage title={error.message} message={error.stack} />;
+  } else {
+    return <ErrorMessage title="Unknown Error" />;
+  }
 }

--- a/remix-app/app/routes/contacts.$contactId.notes.$noteIndex.jsx
+++ b/remix-app/app/routes/contacts.$contactId.notes.$noteIndex.jsx
@@ -1,5 +1,11 @@
 import { json } from "@remix-run/node";
-import { useLoaderData, useNavigate } from "@remix-run/react";
+import {
+  isRouteErrorResponse,
+  useLoaderData,
+  useNavigate,
+  useRouteError,
+} from "@remix-run/react";
+import ErrorMessage from "~/components/ErrorMessage";
 
 export async function loader({ params }) {
   const noteResponse = await fetch(
@@ -37,4 +43,28 @@ export default function Note() {
       </button>
     </div>
   );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    return (
+      <ErrorMessage
+        title={error.status + " " + error.statusText}
+        message={error.data}
+        className="basis-1/4"
+      />
+    );
+  } else if (error instanceof Error) {
+    return (
+      <ErrorMessage
+        title={error.message}
+        message={error.stack}
+        className="basis-1/4"
+      />
+    );
+  } else {
+    return <ErrorMessage title="Unknown Error" className="basis-1/4" />;
+  }
 }


### PR DESCRIPTION
Closes #5 

Implements a generic `ErrorMessage` component and uses it in an `ErrorBoundary` on the contact details and note details routes.

![contact-note-error-boundary](https://github.com/bewildergeist/dob-remix-contacts/assets/121186/b1a80bc8-52f6-4a3f-8fb9-a99051e7ca7c)
